### PR TITLE
add channel_loss

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -50,6 +50,7 @@ channel_amplitude_damping
 channel_amplitude_damping_generalized
 channel_bit_phase_flip
 channel_depolarizing
+channel_loss
 ```
 
 ## Entanglement

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -147,6 +147,29 @@ end
 export channel_depolarizing
 
 """
+    channel_loss(η::Real, d::Integer = 2)
+
+Returns kraus representation of a `d`-dimensional erasure/loss channel of the form
+
+ ρ ↦ η ρ ⊕ (1 - η) tr(ρ) |⊥⟩⟨⊥|. 
+ 
+The output has dimension `d + 1`, with the final basis state representing vacuum.
+"""
+function channel_loss(η::Real, d::Integer = 2)
+    0 ≤ η ≤ 1 || throw(ArgumentError("η must lie in [0, 1]"))
+    d > 0 || throw(ArgumentError("d must be positive"))
+
+    K = [zeros(typeof(η), d + 1, d) for _ ∈ 1:(d + 1)]
+
+    for i ∈ 1:d
+        K[1][i, i] = sqrt(η)
+        K[i + 1][d + 1, i] = sqrt(1 - η)
+    end
+    return K
+end
+export channel_loss
+
+"""
     channel_amplitude_damping(γ::Real)
 
 Return the Kraus operator representation of the amplitude damping channel.

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -18,6 +18,8 @@
         @test applymap(channel_phase_damping(γ), ρ) ≈ applymap(channel_phase_flip((1 + sqrt(1 − γ)) / 2), ρ)
         ρ3 = random_state(T, 3)
         @test applymap(channel_depolarizing(p, 3), ρ3) ≈ white_noise(ρ3, p)
+          K = channel_loss(p, 3)
+        @test applymap(K, ρ3) ≈ Hermitian(cat(p .* ρ3,(1 - p) * tr(ρ3),dims=[1,2]))
         din, dout = 2, 3
         K = [randn(T, dout, din) for _ ∈ 1:3]
         Φ = choi(K)


### PR DESCRIPTION
I added the function channel_loss in src>channels and the corresponding test in test>channels. The function constructs a Kraus representation of the loss/erasure channel

ρ ↦ η ρ ⊕ (1 - η) tr(ρ) |⊥⟩⟨⊥|.

The additional state |⊥⟩ represents an erasure/loss flag. 